### PR TITLE
added the `AppTable::getCacheNameWithAssociated()` method. The `getCa…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 # 2.x branch
 ## 2.30 branch
 ### 2.30.13
-* added `AppTable::getCacheNameWithAssociated()` method.
+* added the `AppTable::getCacheNameWithAssociated()` method. The `getCacheName()` method will now only return the cache
+  name of the current table (string).
 
 ### 2.30.12
 * fixed a bug that caused the "read more" button to disappear;

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -11,27 +11,7 @@ parameters:
 			path: src/Controller/PostsCategoriesController.php
 
 		-
-			message: "#^Parameter \\#2 \\$config of static method Cake\\\\Cache\\\\Cache\\:\\:readMany\\(\\) expects string, array\\|string\\|null given\\.$#"
-			count: 1
-			path: src/Controller/PostsCategoriesController.php
-
-		-
-			message: "#^Parameter \\#2 \\$config of static method Cake\\\\Cache\\\\Cache\\:\\:writeMany\\(\\) expects string, array\\|string\\|null given\\.$#"
-			count: 1
-			path: src/Controller/PostsCategoriesController.php
-
-		-
 			message: "#^Cannot cast array\\|string\\|null to string\\.$#"
-			count: 3
-			path: src/Controller/PostsController.php
-
-		-
-			message: "#^Parameter \\#2 \\$config of static method Cake\\\\Cache\\\\Cache\\:\\:readMany\\(\\) expects string, array\\|string\\|null given\\.$#"
-			count: 3
-			path: src/Controller/PostsController.php
-
-		-
-			message: "#^Parameter \\#2 \\$config of static method Cake\\\\Cache\\\\Cache\\:\\:writeMany\\(\\) expects string, array\\|string\\|null given\\.$#"
 			count: 3
 			path: src/Controller/PostsController.php
 
@@ -39,56 +19,6 @@ parameters:
 			message: "#^Cannot cast array\\|string\\|null to string\\.$#"
 			count: 2
 			path: src/Controller/PostsTagsController.php
-
-		-
-			message: "#^Parameter \\#2 \\$config of static method Cake\\\\Cache\\\\Cache\\:\\:readMany\\(\\) expects string, array\\|string\\|null given\\.$#"
-			count: 2
-			path: src/Controller/PostsTagsController.php
-
-		-
-			message: "#^Parameter \\#2 \\$config of static method Cake\\\\Cache\\\\Cache\\:\\:writeMany\\(\\) expects string, array\\|string\\|null given\\.$#"
-			count: 2
-			path: src/Controller/PostsTagsController.php
-
-		-
-			message: "#^Parameter \\#1 \\$config of static method Cake\\\\Cache\\\\Cache\\:\\:clear\\(\\) expects string, array\\|string\\|null given\\.$#"
-			count: 1
-			path: src/Model/Table/AppTable.php
-
-		-
-			message: "#^Parameter \\#3 \\$config of static method Cake\\\\Cache\\\\Cache\\:\\:remember\\(\\) expects string, array\\|string\\|null given\\.$#"
-			count: 1
-			path: src/Model/Table/PostsTable.php
-
-		-
-			message: "#^Parameter \\#2 \\$config of static method Cake\\\\Cache\\\\Cache\\:\\:read\\(\\) expects string, array\\|string\\|null given\\.$#"
-			count: 1
-			path: src/ORM/PostsAndPagesTables.php
-
-		-
-			message: "#^Parameter \\#3 \\$config of static method Cake\\\\Cache\\\\Cache\\:\\:write\\(\\) expects string, array\\|string\\|null given\\.$#"
-			count: 1
-			path: src/ORM/PostsAndPagesTables.php
-
-		-
-			message: "#^Parameter \\#2 \\$config of static method Cake\\\\Cache\\\\Cache\\:\\:read\\(\\) expects string, array\\|string\\|null given\\.$#"
-			count: 2
-			path: src/TestSuite/PostsAndPagesTablesTestCase.php
-
-		-
-			message: "#^Parameter \\#3 \\$config of static method Cake\\\\Cache\\\\Cache\\:\\:write\\(\\) expects string, array\\|string\\|null given\\.$#"
-			count: 2
-			path: src/TestSuite/PostsAndPagesTablesTestCase.php
-
-		-
-			message: "#^Parameter \\#2 \\$config of static method Cake\\\\Cache\\\\Cache\\:\\:read\\(\\) expects string, array\\|string\\|null given\\.$#"
-			count: 3
-			path: src/Utility/Sitemap/Sitemap.php
-
-		-
-			message: "#^Parameter \\#3 \\$config of static method Cake\\\\Cache\\\\Cache\\:\\:write\\(\\) expects string, array\\|string\\|null given\\.$#"
-			count: 3
-			path: src/Utility/Sitemap/Sitemap.php
 
 		-
 			message: "#^Call to an undefined method DOMDocument\\|SimpleXMLElement\\:\\:asXML\\(\\)\\.$#"
@@ -346,46 +276,6 @@ parameters:
 			path: tests/TestCase/Controller/AppControllerTest.php
 
 		-
-			message: "#^Parameter \\#2 \\$config of static method Cake\\\\Cache\\\\Cache\\:\\:read\\(\\) expects string, array\\|string\\|null given\\.$#"
-			count: 2
-			path: tests/TestCase/Controller/PagesCategoriesControllerTest.php
-
-		-
-			message: "#^Parameter \\#2 \\$config of static method Cake\\\\Cache\\\\Cache\\:\\:read\\(\\) expects string, array\\|string\\|null given\\.$#"
-			count: 1
-			path: tests/TestCase/Controller/PagesControllerTest.php
-
-		-
-			message: "#^Parameter \\#2 \\$config of static method Cake\\\\Cache\\\\Cache\\:\\:read\\(\\) expects string, array\\|string\\|null given\\.$#"
-			count: 1
-			path: tests/TestCase/Controller/PostsCategoriesControllerTest.php
-
-		-
-			message: "#^Parameter \\#2 \\$config of static method Cake\\\\Cache\\\\Cache\\:\\:readMany\\(\\) expects string, array\\|string\\|null given\\.$#"
-			count: 1
-			path: tests/TestCase/Controller/PostsCategoriesControllerTest.php
-
-		-
-			message: "#^Parameter \\#2 \\$config of static method Cake\\\\Cache\\\\Cache\\:\\:read\\(\\) expects string, array\\|string\\|null given\\.$#"
-			count: 1
-			path: tests/TestCase/Controller/PostsControllerTest.php
-
-		-
-			message: "#^Parameter \\#2 \\$config of static method Cake\\\\Cache\\\\Cache\\:\\:readMany\\(\\) expects string, array\\|string\\|null given\\.$#"
-			count: 3
-			path: tests/TestCase/Controller/PostsControllerTest.php
-
-		-
-			message: "#^Parameter \\#2 \\$config of static method Cake\\\\Cache\\\\Cache\\:\\:read\\(\\) expects string, array\\|string\\|null given\\.$#"
-			count: 1
-			path: tests/TestCase/Controller/PostsTagsControllerTest.php
-
-		-
-			message: "#^Parameter \\#2 \\$config of static method Cake\\\\Cache\\\\Cache\\:\\:readMany\\(\\) expects string, array\\|string\\|null given\\.$#"
-			count: 2
-			path: tests/TestCase/Controller/PostsTagsControllerTest.php
-
-		-
 			message: "#^Binary operation \"\\.\" between 'ORDER BY ' and array\\<string\\>\\|string\\|null results in an error\\.$#"
 			count: 1
 			path: tests/TestCase/Model/Table/AppTableTest.php
@@ -393,16 +283,6 @@ parameters:
 		-
 			message: "#^Binary operation \"\\.\" between 'ORDER BY `' and array\\<string\\>\\|string\\|null results in an error\\.$#"
 			count: 1
-			path: tests/TestCase/Model/Table/AppTableTest.php
-
-		-
-			message: "#^Parameter \\#2 \\$config of static method Cake\\\\Cache\\\\Cache\\:\\:read\\(\\) expects string, array\\|string\\|null given\\.$#"
-			count: 4
-			path: tests/TestCase/Model/Table/AppTableTest.php
-
-		-
-			message: "#^Parameter \\#3 \\$config of static method Cake\\\\Cache\\\\Cache\\:\\:write\\(\\) expects string, array\\|string\\|null given\\.$#"
-			count: 2
 			path: tests/TestCase/Model/Table/AppTableTest.php
 
 		-
@@ -414,11 +294,6 @@ parameters:
 			message: "#^Property MeCms\\\\Test\\\\TestCase\\\\Model\\\\Table\\\\AppTableTest\\:\\:\\$PostsCategories \\(MeCms\\\\Model\\\\Table\\\\PostsCategoriesTable\\) on left side of \\?\\?\\= is not nullable\\.$#"
 			count: 1
 			path: tests/TestCase/Model/Table/AppTableTest.php
-
-		-
-			message: "#^Parameter \\#2 \\$config of static method Cake\\\\Cache\\\\Cache\\:\\:read\\(\\) expects string, array\\|string\\|null given\\.$#"
-			count: 4
-			path: tests/TestCase/Model/Table/PostsTableTest.php
 
 		-
 			message: "#^Ternary operator condition is always true\\.$#"
@@ -434,34 +309,4 @@ parameters:
 			message: "#^Property MeCms\\\\Test\\\\TestCase\\\\Model\\\\Table\\\\Traits\\\\NextToBePublishedTraitTest\\:\\:\\$Posts \\(MeCms\\\\Model\\\\Table\\\\PostsTable&PHPUnit\\\\Framework\\\\MockObject\\\\MockObject\\) on left side of \\?\\?\\= is not nullable\\.$#"
 			count: 1
 			path: tests/TestCase/Model/Table/Traits/NextToBePublishedTraitTest.php
-
-		-
-			message: "#^Parameter \\#2 \\$config of static method Cake\\\\Cache\\\\Cache\\:\\:read\\(\\) expects string, array\\|string\\|null given\\.$#"
-			count: 1
-			path: tests/TestCase/Model/Table/UsersTableTest.php
-
-		-
-			message: "#^Parameter \\#2 \\$config of method MeCms\\\\ORM\\\\Query\\:\\:cache\\(\\) expects Cake\\\\Cache\\\\CacheEngine\\|string, array\\|string\\|null given\\.$#"
-			count: 1
-			path: tests/TestCase/ORM/QueryTest.php
-
-		-
-			message: "#^Parameter \\#2 \\$config of static method Cake\\\\Cache\\\\Cache\\:\\:read\\(\\) expects string, array\\|string\\|null given\\.$#"
-			count: 3
-			path: tests/TestCase/Utility/Sitemap/SitemapTest.php
-
-		-
-			message: "#^Parameter \\#2 \\$config of static method Cake\\\\Cache\\\\Cache\\:\\:read\\(\\) expects string, array\\|string\\|null given\\.$#"
-			count: 2
-			path: tests/TestCase/View/Cell/PagesWidgetsCellTest.php
-
-		-
-			message: "#^Parameter \\#2 \\$config of static method Cake\\\\Cache\\\\Cache\\:\\:read\\(\\) expects string, array\\|string\\|null given\\.$#"
-			count: 3
-			path: tests/TestCase/View/Cell/PostsTagsWidgetsCellTest.php
-
-		-
-			message: "#^Parameter \\#2 \\$config of static method Cake\\\\Cache\\\\Cache\\:\\:read\\(\\) expects string, array\\|string\\|null given\\.$#"
-			count: 4
-			path: tests/TestCase/View/Cell/PostsWidgetsCellTest.php
 

--- a/src/Model/Table/AppTable.php
+++ b/src/Model/Table/AppTable.php
@@ -125,17 +125,12 @@ abstract class AppTable extends Table
 
     /**
      * Gets the cache configuration name used by this table
-     * @param bool $associations If `true`, it returns an array that contains also the names of the associated tables
-     * @return string|string[]
+     * @return string
      * @since 2.26.0
      */
-    public function getCacheName(bool $associations = false)
+    public function getCacheName(): string
     {
-        if (!$associations) {
-            return $this->cache ?? '';
-        }
-
-        return array_clean([$this->cache, ...$this->getCacheNameWithAssociated()]);
+        return $this->cache ?? '';
     }
 
     /**

--- a/src/Model/Table/AppTable.php
+++ b/src/Model/Table/AppTable.php
@@ -19,7 +19,6 @@ use Cake\Cache\Cache;
 use Cake\Datasource\EntityInterface;
 use Cake\Event\Event;
 use Cake\I18n\FrozenTime;
-use Cake\ORM\Association;
 use Cake\ORM\Query as CakeQuery;
 use Cake\ORM\Table;
 use MeCms\ORM\Query;

--- a/tests/TestCase/Model/Table/AppTableTest.php
+++ b/tests/TestCase/Model/Table/AppTableTest.php
@@ -179,7 +179,6 @@ class AppTableTest extends TableTestCase
     {
         $this->assertSame('', $this->getTable('ArticlesTable', ['className' => ArticlesTable::class])->getCacheName());
         $this->assertSame('posts', $this->Posts->getCacheName());
-        $this->assertSame(['posts', 'users'], $this->Posts->getCacheName(true));
     }
 
     /**


### PR DESCRIPTION
…cheName()` method will now only return the cache

  name of the current table (string)