### PR TITLE
the `UsersTable` belongs to `UsersGroups` and no longer to `Groups` (…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # 2.x branch
 ## 2.32 branch
 ### 2.32.1
+* the `UsersTable` belongs to `UsersGroups` and no longer to `Groups` (the name of the association has changed). This
+  avoids using a reserved word for mysql. The property name (`group`) remained unchanged;
 * improved the query filter for posts and pages in the admin panel: now the `title` field works for both title and slug;
 * `User::_getLastLogins()` returns an array and no longer a collection;
 * `assertSqlEndsWith()` and `assertSqlEndsNotWith()` methods have been replaced with `assertStringEndsWith()` and 

--- a/src/Command/AddUserCommand.php
+++ b/src/Command/AddUserCommand.php
@@ -34,7 +34,7 @@ class AddUserCommand extends Command
     protected function buildOptionParser(ConsoleOptionParser $parser): ConsoleOptionParser
     {
         return $parser->setDescription(__d('me_cms', 'Adds an user'))
-            ->addOption('group', ['short' => 'g', 'help' => __d('me_cms', 'Group ID')]);
+            ->addOption('group', ['short' => 'g', 'help' => __d('me_cms', 'User Group ID')]);
     }
 
     /**
@@ -49,7 +49,7 @@ class AddUserCommand extends Command
         /** @var \MeCms\Model\Table\UsersTable $Users */
         $Users = $this->getTableLocator()->get('MeCms.Users');
 
-        $groups = $Users->Groups->find('list')->all();
+        $groups = $Users->UsersGroups->find('list')->all();
         if ($groups->isEmpty()) {
             return $io->error(__d('me_cms', 'Before you can manage users, you have to create at least a user group'));
         }
@@ -68,10 +68,10 @@ class AddUserCommand extends Command
             $user[$field] = $io->ask($question);
         }
 
-        //Asks for group, if not passed as option
+        //Asks for user group, if not passed as option
         $user['group_id'] = $args->getOption('group');
         if (!$user['group_id']) {
-            //Formats groups
+            //Formats user groups
             foreach ($groups as $id => $group) {
                 $groups[$id] = [(string)$id, $group];
             }
@@ -88,7 +88,7 @@ class AddUserCommand extends Command
             }
         }
 
-        //Checks the group IDs
+        //Checks the user group
         if (!array_key_exists((string)$user['group_id'], $groups)) {
             return $io->error(__d('me_cms', 'Invalid group ID'));
         }

--- a/src/Command/Install/CreateGroupsCommand.php
+++ b/src/Command/Install/CreateGroupsCommand.php
@@ -26,6 +26,7 @@ use MeTools\Command\Command;
 /**
  * Creates the user groups
  * @property \MeCms\Model\Table\UsersGroupsTable $UsersGroups
+ * @todo should become `CreateUsersGroupsCommand`
  */
 class CreateGroupsCommand extends Command
 {
@@ -55,7 +56,7 @@ class CreateGroupsCommand extends Command
             return $io->error(__d('me_cms', 'Some user groups already exist'));
         }
 
-        //Truncates the table (this resets IDs), then saves groups
+        //Truncates the table (this resets IDs), then saves user groups
         $command = 'TRUNCATE TABLE `%s`';
         $connection = $UsersGroups->getConnection();
         if ($connection->getDriver() instanceof Sqlite) {

--- a/src/Command/UsersCommand.php
+++ b/src/Command/UsersCommand.php
@@ -49,7 +49,7 @@ class UsersCommand extends Command
         $Users = $this->getTableLocator()->get('MeCms.Users');
 
         return $Users->find()
-            ->contain('Groups')
+            ->contain('UsersGroups')
             ->formatResults(fn(CollectionInterface $results): CollectionInterface => $results->map(function (User $user): array {
                 $result = array_map(fn(string $key): string => (string)$user->get($key), ['id', 'username', 'full_name', 'email', 'post_count', 'created']);
                 $result['group'] = $user->get('group')->get('label') ?: $user->get('group');

--- a/src/Controller/Admin/UsersController.php
+++ b/src/Controller/Admin/UsersController.php
@@ -44,7 +44,7 @@ class UsersController extends AppController
         }
 
         if ($this->getRequest()->is('action', ['index', 'add', 'edit'])) {
-            $groups = $this->Users->Groups->getList()->all();
+            $groups = $this->Users->UsersGroups->getList()->all();
             if ($groups->isEmpty()) {
                 $this->Flash->alert(__d('me_cms', 'You must first create an user group'));
 
@@ -86,7 +86,7 @@ class UsersController extends AppController
      */
     public function index(): void
     {
-        $query = $this->Users->find()->contain(['Groups' => ['fields' => ['id', 'label']]]);
+        $query = $this->Users->find()->contain(['UsersGroups' => ['fields' => ['id', 'label']]]);
 
         $this->paginate['order'] = ['username' => 'ASC'];
 
@@ -103,7 +103,7 @@ class UsersController extends AppController
     public function view(string $id): void
     {
         $user = $this->Users->findById($id)
-            ->contain(['Groups' => ['fields' => ['id', 'label']]])
+            ->contain(['UsersGroups' => ['fields' => ['id', 'label']]])
             ->firstOrFail();
 
         $this->set(compact('user'));

--- a/src/Controller/Component/AuthenticationComponent.php
+++ b/src/Controller/Component/AuthenticationComponent.php
@@ -79,9 +79,9 @@ class AuthenticationComponent extends BaseAuthenticationComponent
     }
 
     /**
-     * Checks whether the logged user belongs to a group.
+     * Checks whether the logged user belongs to a user group.
      *
-     * If you compare with several groups, it will check that at least one matches.
+     * If you compare with several user groups, it will check that at least one matches.
      * @param string ...$group User group
      * @return bool
      * @since 2.31.8

--- a/src/Model/Table/UsersTable.php
+++ b/src/Model/Table/UsersTable.php
@@ -28,8 +28,8 @@ use MeCms\ORM\Query;
 
 /**
  * Users model
- * @property \MeCms\Model\Table\UsersGroupsTable&\Cake\ORM\Association\BelongsTo $Groups
  * @property \MeCms\Model\Table\PostsTable&\Cake\ORM\Association\HasMany $Posts
+ * @property \MeCms\Model\Table\UsersGroupsTable&\Cake\ORM\Association\BelongsTo $UsersGroups
  * @property \MeCms\Model\Table\TokensTable&\Cake\ORM\Association\HasMany $Tokens
  * @method \MeCms\ORM\Query findByActiveAndBanned(bool $isActive, bool $isBanned)
  * @method \MeCms\ORM\Query findActiveByEmail(string $email)
@@ -82,7 +82,7 @@ class UsersTable extends AppTable
      */
     public function buildRules(RulesChecker $rules): RulesChecker
     {
-        return $rules->add($rules->existsIn(['group_id'], 'Groups', I18N_SELECT_VALID_OPTION))
+        return $rules->add($rules->existsIn(['group_id'], 'UsersGroups', I18N_SELECT_VALID_OPTION))
             ->add($rules->isUnique(['email'], I18N_VALUE_ALREADY_USED))
             ->add($rules->isUnique(['username'], I18N_VALUE_ALREADY_USED));
     }
@@ -106,7 +106,7 @@ class UsersTable extends AppTable
      */
     public function findAuth(Query $query): Query
     {
-        return $query->contain([$this->Groups->getAlias() => ['fields' => ['name']]]);
+        return $query->contain([$this->UsersGroups->getAlias() => ['fields' => ['name']]]);
     }
 
     /**
@@ -157,15 +157,16 @@ class UsersTable extends AppTable
         $this->setDisplayField('username');
         $this->setPrimaryKey('id');
 
-        $this->belongsTo('Groups', ['className' => UsersGroupsTable::class])
+        $this->belongsTo('UsersGroups', ['className' => UsersGroupsTable::class])
             ->setForeignKey('group_id')
-            ->setJoinType('INNER');
+            ->setJoinType('INNER')
+            ->setProperty('group');
 
         $this->hasMany('Posts', ['className' => PostsTable::class])->setForeignKey('user_id');
         $this->hasMany('Tokens', ['className' => TokensTable::class])->setForeignKey('user_id');
 
         $this->addBehavior('Timestamp');
-        $this->addBehavior('CounterCache', ['Groups' => ['user_count']]);
+        $this->addBehavior('CounterCache', ['UsersGroups' => ['user_count']]);
 
         $this->_validatorClass = UserValidator::class;
     }

--- a/src/TestSuite/Admin/ControllerTestCase.php
+++ b/src/TestSuite/Admin/ControllerTestCase.php
@@ -92,10 +92,11 @@ abstract class ControllerTestCase extends BaseControllerTestCase
     }
 
     /**
-     * Assert that all groups are authorized to perform `$action`, calling `isAuthorized()` method for the current controller
+     * Assert that all user groups are authorized to perform `$action`, calling `isAuthorized()` method for the current controller
      * @param string $action Action name
      * @param string $message The failure message that will be appended to the generated message
      * @return void
+     * @todo should become `assertAllUserGroupsAreAuthorized()`
      */
     protected function assertAllGroupsAreAuthorized(string $action, string $message = ''): void
     {

--- a/src/View/Helper/IdentityHelper.php
+++ b/src/View/Helper/IdentityHelper.php
@@ -27,9 +27,9 @@ use Tools\Exceptionist;
 class IdentityHelper extends CakeIdentityHelper
 {
     /**
-     * Checks whether the logged user belongs to a group.
+     * Checks whether the logged user belongs to a user group.
      *
-     * If you compare with several groups, it will check that at least one matches.
+     * If you compare with several user groups, it will check that at least one matches.
      * @param string ...$group User group
      * @return bool
      * @throws \ErrorException

--- a/tests/TestCase/Command/AddUserCommandTest.php
+++ b/tests/TestCase/Command/AddUserCommandTest.php
@@ -93,8 +93,8 @@ class AddUserCommandTest extends CommandTestCase
         $this->assertErrorContains('Field `password`: the password should contain at least one symbol');
         $this->assertErrorContains('Field `password_repeat`: passwords don\'t match');
 
-        //Tries with no groups
-        $Users->Groups->deleteAll(['id IS NOT' => null]);
+        //Tries with no user groups
+        $Users->UsersGroups->deleteAll(['id IS NOT' => null]);
         $this->_in = null;
         $this->exec('me_cms.add_user -v');
         $this->assertExitSuccess();

--- a/tests/TestCase/Command/GroupsCommandTest.php
+++ b/tests/TestCase/Command/GroupsCommandTest.php
@@ -50,7 +50,7 @@ class GroupsCommandTest extends CommandTestCase
         $this->assertExitSuccess();
         array_walk($expectedRows, [$this, 'assertOutputContainsRow']);
 
-        //Deletes all groups
+        //Deletes all user groups
         $UsersGroups->deleteAll(['id IS NOT' => null]);
         $this->exec('me_cms.groups');
         $this->assertExitSuccess();

--- a/tests/TestCase/Controller/Admin/UsersControllerTest.php
+++ b/tests/TestCase/Controller/Admin/UsersControllerTest.php
@@ -71,7 +71,7 @@ class UsersControllerTest extends ControllerTestCase
         $this->assertEmpty($this->viewVariable('groups'));
 
         //Deletes all categories
-        $this->Table->Groups->deleteAll(['id IS NOT' => null]);
+        $this->Table->UsersGroups->deleteAll(['id IS NOT' => null]);
 
         //`add` and `edit` actions don't work
         foreach (['index', 'add', 'edit'] as $action) {

--- a/tests/TestCase/Controller/Component/AuthenticationComponentTest.php
+++ b/tests/TestCase/Controller/Component/AuthenticationComponentTest.php
@@ -59,7 +59,7 @@ class AuthenticationComponentTest extends ComponentTestCase
             /** @var \MeCms\Model\Table\UsersTable $UsersTable */
             $UsersTable = $this->getTable('MeCms.Users');
             /** @var \MeCms\Model\Entity\User $User */
-            $User = $UsersTable->findByGroupId(2)->contain(['Groups' => ['fields' => ['name']]])->firstOrFail();
+            $User = $UsersTable->findByGroupId(2)->contain(['UsersGroups' => ['fields' => ['name']]])->firstOrFail();
             $this->User = $User;
         }
 

--- a/tests/TestCase/Model/Table/UsersTableTest.php
+++ b/tests/TestCase/Model/Table/UsersTableTest.php
@@ -117,9 +117,10 @@ class UsersTableTest extends TableTestCase
         $this->assertEquals('username', $this->Table->getDisplayField());
         $this->assertEquals('id', $this->Table->getPrimaryKey());
 
-        $this->assertBelongsTo($this->Table->Groups);
-        $this->assertEquals('group_id', $this->Table->Groups->getForeignKey());
-        $this->assertEquals('INNER', $this->Table->Groups->getJoinType());
+        $this->assertBelongsTo($this->Table->UsersGroups);
+        $this->assertEquals('group_id', $this->Table->UsersGroups->getForeignKey());
+        $this->assertEquals('INNER', $this->Table->UsersGroups->getJoinType());
+        $this->assertSame('group', $this->Table->UsersGroups->getProperty());
 
         $this->assertHasMany($this->Table->Posts);
         $this->assertEquals('user_id', $this->Table->Posts->getForeignKey());
@@ -164,7 +165,7 @@ class UsersTableTest extends TableTestCase
     public function testFindAuth(): void
     {
         $query = $this->Table->find('auth');
-        $this->assertStringEndsWith('FROM users Users INNER JOIN users_groups Groups ON Groups.id = Users.group_id', $query->sql());
+        $this->assertStringEndsWith('FROM users Users INNER JOIN users_groups UsersGroups ON UsersGroups.id = Users.group_id', $query->sql());
     }
 
     /**

--- a/tests/TestCase/TestSuite/TableTestCaseTest.php
+++ b/tests/TestCase/TestSuite/TableTestCaseTest.php
@@ -87,6 +87,6 @@ class TableTestCaseTest extends TestCase
         $TableTestCase->assertHasMany($TableTestCase->Table->Posts);
 
         $this->expectAssertionFailed('Failed asserting that `MeCms\Model\Table\UsersGroupsTable` is an instance of `Cake\ORM\Association\HasMany`');
-        $TableTestCase->assertHasMany($TableTestCase->Table->Groups);
+        $TableTestCase->assertHasMany($TableTestCase->Table->UsersGroups);
     }
 }


### PR DESCRIPTION
…the name of the association has changed). This

  avoids using a reserved word for mysql. The property name (`group`) remained unchanged